### PR TITLE
Increase scan rate and USB reporting rate

### DIFF
--- a/keyboards/durgod/boards/DURGOD_STM32_F070/chconf.h
+++ b/keyboards/durgod/boards/DURGOD_STM32_F070/chconf.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#define CH_CFG_ST_FREQUENCY 10000
+#define CH_CFG_ST_FREQUENCY 1000
 
 #define CH_CFG_ST_TIMEDELTA 0
-
-#define CH_CFG_OPTIMIZE_SPEED FALSE
 
 #define CH_CFG_USE_REGISTRY TRUE
 

--- a/keyboards/durgod/boards/DURGOD_STM32_F070/mcuconf.h
+++ b/keyboards/durgod/boards/DURGOD_STM32_F070/mcuconf.h
@@ -85,13 +85,12 @@
  */
 #define STM32_GPT_USE_TIM1                  FALSE
 #define STM32_GPT_USE_TIM2                  FALSE
-#define STM32_GPT_USE_TIM3                  FALSE
+#define STM32_GPT_USE_TIM3                  TRUE
 #define STM32_GPT_USE_TIM14                 FALSE
 #define STM32_GPT_TIM1_IRQ_PRIORITY         2
 #define STM32_GPT_TIM2_IRQ_PRIORITY         2
 #define STM32_GPT_TIM3_IRQ_PRIORITY         2
 #define STM32_GPT_TIM14_IRQ_PRIORITY        2
-
 /*
  * I2C driver system settings.
  */

--- a/keyboards/durgod/k320/config.h
+++ b/keyboards/durgod/k320/config.h
@@ -24,6 +24,7 @@
 #define DEVICE_VER      0x0001
 #define MANUFACTURER    Hoksi Technology
 #define PRODUCT         DURGOD Taurus K320 (QMK)
+#define USB_POLLING_INTERVAL_MS 1
 
 /* key matrix size */
 #define MATRIX_ROWS 7

--- a/keyboards/durgod/k320/halconf.h
+++ b/keyboards/durgod/k320/halconf.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define HAL_USE_GPT                 TRUE
+
+#include_next <halconf.h>

--- a/keyboards/durgod/k320/k320.c
+++ b/keyboards/durgod/k320/k320.c
@@ -16,6 +16,9 @@
 
 #include "k320.h"
 
+#include <ch.h>
+#include <hal.h>
+
 /* Private Functions */
 void off_all_leds(void) {
     writePinHigh(LED_CAPS_LOCK_PIN);
@@ -40,7 +43,6 @@ void led_init_ports(void) {
     off_all_leds();
 }
 
-
 #ifndef WINLOCK_DISABLED
 static bool win_key_locked = false;
 
@@ -60,3 +62,18 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     return process_record_user(keycode, record);
 }
 #endif /* WINLOCK_DISABLED */
+
+/* Wait 30us between columns */
+#ifndef MATRIX_IO_DELAY
+#    define MATRIX_IO_DELAY 30
+#endif
+
+/* 1 MHz interval, no callback */
+static const GPTConfig gpt3cfg = {
+    100000, NULL, 0, 0
+};
+
+void matrix_output_unselect_delay(void) {
+    gptStart(&GPTD3, &gpt3cfg);
+    gptPolledDelay(&GPTD3, MATRIX_IO_DELAY);
+}


### PR DESCRIPTION
Observed scan rate is now 1820Hz

Removed CH_CFG_OPTIMIZE_SPEED=FALSE as it actually increases the code size by 20 bytes

This fixes https://github.com/qmk/qmk_firmware/issues/12198
