### PR TITLE
Jump to bootloader when the hardware reset button is pressed

### DIFF
--- a/keyboards/durgod/k3x0/config.h
+++ b/keyboards/durgod/k3x0/config.h
@@ -48,3 +48,4 @@
 #define LED_PIN_ON_STATE    0
 
 /* Original hardware "reset" button on pin D2 */
+#define HARDWARE_RESET_PIN  D2

--- a/keyboards/durgod/k3x0/halconf.h
+++ b/keyboards/durgod/k3x0/halconf.h
@@ -1,0 +1,22 @@
+/* Copyright 2021 Simon Arlott
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define HAL_USE_PAL                 TRUE
+#define PAL_USE_CALLBACKS           TRUE
+
+#include_next <halconf.h>

--- a/keyboards/durgod/k3x0/k3x0.c
+++ b/keyboards/durgod/k3x0/k3x0.c
@@ -16,6 +16,8 @@
  */
 
 #include "k3x0.h"
+#include <ch.h>
+#include <hal.h>
 
 /* Private Functions */
 void off_all_leds(void) {
@@ -69,3 +71,21 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
     return process_record_user(keycode, record);
 }
 #endif /* WINLOCK_DISABLED */
+
+#ifndef HW_RESET_PIN_DISABLED
+static void hardware_reset_cb(void *arg) {
+    chSysLockFromISR();
+    bootloader_jump();
+    chSysUnlockFromISR();
+}
+#endif
+
+void keyboard_pre_init_kb(void) {
+    setPinInputHigh(HARDWARE_RESET_PIN);
+
+#ifndef HW_RESET_PIN_DISABLED
+    /* Jump to bootloader when the hardware reset button is pressed */
+    palEnablePadEvent(PAL_PORT(HARDWARE_RESET_PIN), PAL_PAD(HARDWARE_RESET_PIN), PAL_EVENT_MODE_FALLING_EDGE);
+    palSetPadCallback(PAL_PORT(HARDWARE_RESET_PIN), PAL_PAD(HARDWARE_RESET_PIN), hardware_reset_cb, NULL);
+#endif
+}

--- a/keyboards/durgod/k3x0/k3x0.c
+++ b/keyboards/durgod/k3x0/k3x0.c
@@ -87,5 +87,10 @@ void keyboard_pre_init_kb(void) {
     /* Jump to bootloader when the hardware reset button is pressed */
     palEnablePadEvent(PAL_PORT(HARDWARE_RESET_PIN), PAL_PAD(HARDWARE_RESET_PIN), PAL_EVENT_MODE_FALLING_EDGE);
     palSetPadCallback(PAL_PORT(HARDWARE_RESET_PIN), PAL_PAD(HARDWARE_RESET_PIN), hardware_reset_cb, NULL);
+
+    /* The interrupt is edge-triggered so check that it's not already pressed */
+    if (!readPin(HARDWARE_RESET_PIN)) {
+        bootloader_jump();
+    }
 #endif
 }


### PR DESCRIPTION
Set the hardware reset button up to immediately jump to the bootloader.

Primarily so I can put the front cover back on and not have to worry about being unable to get into the bootloader as long as `keyboard_pre_init_kb` runs...